### PR TITLE
FORGE-617 upgrade servlet-filter-decorators to BrXM v17

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Bloomreach Forge Servlet Decorators Plugin
-Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
 
 This product includes software developed by:
 Bloomreach B.V., Amsterdam, The Netherlands (http://www.bloomreach.com/);

--- a/cms/pom.xml
+++ b/cms/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2018 Hippo B.V. (http://www.onehippo.com)
+  Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/cms/pom.xml
+++ b/cms/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.onehippo.forge.servlet-filter-decorators</groupId>
     <artifactId>servlet-filter-decorators</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>servlet-filter-decorators-cms</artifactId>
   <name>Servlet filter decorators CMS</name>
@@ -48,7 +48,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/cms/src/main/java/org/onehippo/forge/servlet/decorators/cms/CmsDecoratorFilter.java
+++ b/cms/src/main/java/org/onehippo/forge/servlet/decorators/cms/CmsDecoratorFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cms/src/main/java/org/onehippo/forge/servlet/decorators/cms/CmsUndecorateFilter.java
+++ b/cms/src/main/java/org/onehippo/forge/servlet/decorators/cms/CmsUndecorateFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cms/src/main/java/org/onehippo/forge/servlet/decorators/service/CmsDecoratorConfigurationLoader.java
+++ b/cms/src/main/java/org/onehippo/forge/servlet/decorators/service/CmsDecoratorConfigurationLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cms/src/main/java/org/onehippo/forge/servlet/decorators/service/ServletDecoratorModule.java
+++ b/cms/src/main/java/org/onehippo/forge/servlet/decorators/service/ServletDecoratorModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cms/src/main/java/org/onehippo/forge/servlet/decorators/service/ServletDecoratorService.java
+++ b/cms/src/main/java/org/onehippo/forge/servlet/decorators/service/ServletDecoratorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cms/src/main/java/org/onehippo/forge/servlet/decorators/service/ServletDecoratorServiceImpl.java
+++ b/cms/src/main/java/org/onehippo/forge/servlet/decorators/service/ServletDecoratorServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2018 Hippo B.V. (http://www.onehippo.com)
+  Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.onehippo.forge.servlet-filter-decorators</groupId>
     <artifactId>servlet-filter-decorators</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>servlet-filter-decorators-common</artifactId>
   <packaging>jar</packaging>
@@ -53,7 +53,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/common/src/main/java/org/onehippo/forge/servlet/decorators/ConfigurableDecoratorFilter.java
+++ b/common/src/main/java/org/onehippo/forge/servlet/decorators/ConfigurableDecoratorFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/onehippo/forge/servlet/decorators/common/CommonUndecorateFilter.java
+++ b/common/src/main/java/org/onehippo/forge/servlet/decorators/common/CommonUndecorateFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/onehippo/forge/servlet/decorators/common/DecoratorConfiguration.java
+++ b/common/src/main/java/org/onehippo/forge/servlet/decorators/common/DecoratorConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/onehippo/forge/servlet/decorators/common/DecoratorConfigurationLoader.java
+++ b/common/src/main/java/org/onehippo/forge/servlet/decorators/common/DecoratorConfigurationLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/onehippo/forge/servlet/decorators/common/DecoratorConst.java
+++ b/common/src/main/java/org/onehippo/forge/servlet/decorators/common/DecoratorConst.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/onehippo/forge/servlet/decorators/common/HippoDecoratedServletRequest.java
+++ b/common/src/main/java/org/onehippo/forge/servlet/decorators/common/HippoDecoratedServletRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hst/pom.xml
+++ b/hst/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.onehippo.forge.servlet-filter-decorators</groupId>
     <artifactId>servlet-filter-decorators</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>servlet-filter-decorators-hst</artifactId>
   <name>Servlet filter decorators  HST</name>
@@ -45,7 +45,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/hst/pom.xml
+++ b/hst/pom.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>

--- a/hst/src/main/java/org/onehippo/forge/servlet/decorators/hst/HstDecorateFilter.java
+++ b/hst/src/main/java/org/onehippo/forge/servlet/decorators/hst/HstDecorateFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hst/src/main/java/org/onehippo/forge/servlet/decorators/hst/HstDecoratorConfigurationLoader.java
+++ b/hst/src/main/java/org/onehippo/forge/servlet/decorators/hst/HstDecoratorConfigurationLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hst/src/main/java/org/onehippo/forge/servlet/decorators/hst/HstUndecorateFilter.java
+++ b/hst/src/main/java/org/onehippo/forge/servlet/decorators/hst/HstUndecorateFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hst/src/main/java/org/onehippo/forge/servlet/decorators/hst/ServletDecoratorEventListener.java
+++ b/hst/src/main/java/org/onehippo/forge/servlet/decorators/hst/ServletDecoratorEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hst/src/main/resources/META-INF/hst-assembly/addon/module.xml
+++ b/hst/src/main/resources/META-INF/hst-assembly/addon/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+  Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/hst/src/main/resources/META-INF/hst-assembly/addon/org/onehippo/forge/servlet/decorators/servlet-decorators.xml
+++ b/hst/src/main/resources/META-INF/hst-assembly/addon/org/onehippo/forge/servlet/decorators/servlet-decorators.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+  Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+  Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.onehippo.cms7</groupId>
     <artifactId>hippo-cms7-release</artifactId>
-    <version>17.0.0</version>
+    <version>17.1.0</version>
   </parent>
 
   <groupId>org.onehippo.forge.servlet-filter-decorators</groupId>
@@ -143,7 +143,7 @@
   </distributionManagement>
 
   <issueManagement>
-    <url>https://issues.onehippo.com/browse/FORGE</url>
+    <url>https://bloomreach.atlassian.net/browse/FORGE</url>
   </issueManagement>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.onehippo.cms7</groupId>
     <artifactId>hippo-cms7-release</artifactId>
-    <version>16.0.0</version>
+    <version>17.0.0</version>
   </parent>
 
   <groupId>org.onehippo.forge.servlet-filter-decorators</groupId>
   <artifactId>servlet-filter-decorators</artifactId>
-  <version>2.0.1-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Servlet filter decorators module</name>
   <description>Servlet filter decorators module</description>
@@ -95,12 +95,12 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>jcl-over-slf4j</artifactId>
-        <version>${slf4j.version}</version>
+        <version>${slf4j2.version}</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-slf4j-impl</artifactId>
+        <artifactId>log4j-slf4j2-impl</artifactId>
         <version>${log4j2.version}</version>
         <scope>provided</scope>
       </dependency>

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+  Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/src/site/markdown/install.md
+++ b/src/site/markdown/install.md
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+  Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/src/site/markdown/release-notes.md
+++ b/src/site/markdown/release-notes.md
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+  Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -17,10 +17,14 @@
 ## Version Compatibility
 | Version | Bloomreach XM Version |
 |---------|-----------------------|
+| 3.x     | 17.x                  |
 | 2.x     | 16.x                  |
 | 1.x     | 12.x                  |
 
 ## Release Notes
+
+### 3.0.0
++ [FORGE-617](https://bloomreach.atlassian.net/browse/FORGE-617) : Upgrade to Bloomreach Experience Manager 17
 
 ### 2.0.0
 + [FORGE-555](https://issues.onehippo.com/browse/FORGE-555) : Upgrade to Bloomreach Experience Manager 16

--- a/src/site/markdown/usage.md
+++ b/src/site/markdown/usage.md
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+  Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+    Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
   <skin>
     <groupId>org.bloomreach.forge.mavenskin</groupId>
     <artifactId>forge-maven-skin</artifactId>
-    <version>3.2.1</version>
+    <version>3.2.2</version>
   </skin>
 
   <publishDate format="d MMMM yyyy"/>


### PR DESCRIPTION
## What

Upgrades the `servlet-filter-decorators` plugin from BrXM v16 to v17:

- Parent POM `hippo-cms7-release` bumped `16.0.0` → `17.0.0`
- Project version `2.0.1-SNAPSHOT` → `3.0.0-SNAPSHOT` across all 4 POMs
- `log4j-slf4j-impl` → `log4j-slf4j2-impl` (artifact renamed for SLF4J 2 bridge in Log4j 2.x)
- `${slf4j.version}` → `${slf4j2.version}` (property renamed in v17 platform BOM)

A `support/2.x` maintenance branch was cut from `develop` before this change to preserve the BrXM v16-compatible release line.

## Why

Resolves [FORGE-617](https://bloomreach.atlassian.net/browse/FORGE-617)

BrXM v17 requires Java 21 and ships updated dependency versions. The plugin must align its parent BOM and dependency coordinates to compile and run on the v17 platform.

## How to test

- Build with JDK 21: `JAVA_HOME=<java21> mvn clean install` → should produce `BUILD SUCCESS`
- Deploy `3.0.0-SNAPSHOT` JARs into a BrXM v17 project and verify filter decoration works on HST and CMS channels

## Checklist

- [x] All 4 modules compile with `release 21` (javac)
- [x] `mvn clean install` passing (2 attempts)
- [x] No breaking API changes (jakarta namespace already migrated in v16)
- [x] `support/2.x` branch created and pushed to preserve v16 line

🤖 Implemented with Claude Code